### PR TITLE
Support self-closing HTML and component tags

### DIFF
--- a/src/djule/compiler/plan_support.py
+++ b/src/djule/compiler/plan_support.py
@@ -134,6 +134,9 @@ class DjulePlanMixin:
             parts: list[PlanPart] = [StaticPart(f"<{node.tag}")]
             for attribute in node.attributes:
                 parts.extend(self._compile_attribute_parts(attribute, bindings))
+            if node.self_closing:
+                parts.append(StaticPart(" />"))
+                return self._merge_static_parts(parts)
             parts.append(StaticPart(">"))
             parts.extend(self._compile_children_plan(node.children, bindings))
             parts.append(StaticPart(f"</{node.tag}>"))
@@ -235,6 +238,8 @@ class DjulePlanMixin:
             self._track_plan_dependency(component.renderer.module_path)
 
         prop_bindings = self._build_component_bindings(node, bindings)
+        if self._component_accepts_children(component) and "children" not in prop_bindings:
+            prop_bindings["children"] = ("literal", SafeHtml(""))
 
         static_props = self._static_props_from_bindings(prop_bindings)
         if static_props is not None and (

--- a/src/djule/compiler/render_support.py
+++ b/src/djule/compiler/render_support.py
@@ -244,6 +244,8 @@ class DjuleRenderMixin:
     def _render_element_node(self, node: ElementNode, env: dict[str, object]) -> SafeHtml:
         """Render a plain HTML element with rendered attributes and children."""
         rendered_attributes = self._render_attributes(node.attributes, env)
+        if node.self_closing:
+            return SafeHtml(f"<{node.tag}{rendered_attributes} />")
         rendered_children = self._render_children(node.children, env)
         return SafeHtml(f"<{node.tag}{rendered_attributes}>{rendered_children}</{node.tag}>")
 

--- a/src/djule/compiler/renderer.py
+++ b/src/djule/compiler/renderer.py
@@ -21,7 +21,7 @@ class DjuleRenderer(DjuleCacheMixin, DjulePlanMixin, DjuleImportMixin, DjuleRend
     responsibilities remain easier to reason about.
     """
 
-    CACHE_VERSION: ClassVar[int] = 6
+    CACHE_VERSION: ClassVar[int] = 7
     _parsed_module_cache: ClassVar[dict[Path, tuple[int, int, Module]]] = {}
     _compiled_expr_cache: ClassVar[dict[str, CodeType]] = {}
     _entry_plan_cache: ClassVar[

--- a/src/djule/parser/ast_nodes.py
+++ b/src/djule/parser/ast_nodes.py
@@ -88,6 +88,7 @@ class ElementNode:
     tag: str
     attributes: list[AttributeNode]
     children: list["MarkupNode"]
+    self_closing: bool = False
     type: str = field(init=False, default="ElementNode")
 
 
@@ -97,6 +98,7 @@ class ComponentNode:
     name: str
     attributes: list[AttributeNode]
     children: list["MarkupNode"]
+    self_closing: bool = False
     line: int = field(default=0, compare=False)
     column: int = field(default=0, compare=False)
     type: str = field(init=False, default="ComponentNode")

--- a/src/djule/parser/lexer.py
+++ b/src/djule/parser/lexer.py
@@ -361,7 +361,7 @@ class DjuleLexer:
                 continue
 
             if self._starts_markup_fragment():
-                name, is_component, is_closing = self._lex_tag()
+                name, is_component, is_closing, is_self_closing = self._lex_tag()
                 if is_closing:
                     if not tag_stack:
                         raise LexerError("Unexpected closing tag", self.line, self.column)
@@ -374,7 +374,7 @@ class DjuleLexer:
                         )
                     if not tag_stack:
                         return
-                else:
+                elif not is_self_closing:
                     tag_stack.append((name, is_component))
                 continue
 
@@ -410,12 +410,13 @@ class DjuleLexer:
         self.advance()  # >
         self._push_token(TokenType.DECLARATION, self.source[start:self.index], line, column)
 
-    def _lex_tag(self) -> tuple[str, bool, bool]:
+    def _lex_tag(self) -> tuple[str, bool, bool, bool]:
         """Lex one opening or closing tag and return its classification.
 
-        The returned tuple is `(name, is_component, is_closing)`. Tag names may
-        include `_`, `-`, and `.` so namespaced component tags are supported.
-        If the tag has no name or never closes with `>`, tokenization fails.
+        The returned tuple is `(name, is_component, is_closing, is_self_closing)`.
+        Tag names may include `_`, `-`, and `.` so namespaced component tags are
+        supported. Opening tags may end with `/>`; closing tags must still end
+        with a plain `>`.
         """
         line, column = self.line, self.column
         is_closing = self.peek(1) == "/"
@@ -446,12 +447,18 @@ class DjuleLexer:
         while not self.is_at_end() and self.peek() in " \t":
             self.advance()
 
+        if not is_closing and self.peek() == "/" and self.peek(1) == ">":
+            self._push_token(TokenType.SELF_TAG_END, "/>", self.line, self.column)
+            self.advance()
+            self.advance()
+            return name, is_component, is_closing, True
+
         if self.peek() != ">":
             raise LexerError("Expected > to close tag", self.line, self.column)
 
         self._push_token(TokenType.TAG_END, ">", self.line, self.column)
         self.advance()
-        return name, is_component, is_closing
+        return name, is_component, is_closing, False
 
     def _lex_tag_attributes(self, tag_name: str, tag_line: int, tag_column: int) -> None:
         """Lex all attributes for the current opening tag.
@@ -468,7 +475,11 @@ class DjuleLexer:
             if self.peek() in {">", ""}:
                 return
 
-            if self.peek() in {"<", "/"}:
+            if self.peek() == "<":
+                raise LexerError(f"Expected > to close tag <{tag_name}>", tag_line, tag_column)
+            if self.peek() == "/":
+                if self.peek(1) == ">":
+                    return
                 raise LexerError(f"Expected > to close tag <{tag_name}>", tag_line, tag_column)
 
             line, column = self.line, self.column

--- a/src/djule/parser/parser.py
+++ b/src/djule/parser/parser.py
@@ -338,6 +338,8 @@ class DjuleParser:
         """Parse a plain HTML-like element and all of its child markup."""
         open_token = self._consume(TokenType.HTML_TAG_OPEN, "Expected HTML opening tag")
         attributes = self._parse_attributes()
+        if self._match(TokenType.SELF_TAG_END):
+            return ElementNode(tag=open_token.value, attributes=attributes, children=[], self_closing=True)
         self._consume(TokenType.TAG_END, "Expected '>' after opening tag")
         children = self._parse_children_until(TokenType.HTML_TAG_CLOSE, open_token.value)
         self._consume(TokenType.HTML_TAG_CLOSE, f"Expected closing tag </{open_token.value}>")
@@ -357,6 +359,15 @@ class DjuleParser:
                 raise self._error(
                     "The 'children' prop is reserved for nested component content; use content between the tags instead"
                 )
+        if self._match(TokenType.SELF_TAG_END):
+            return ComponentNode(
+                name=open_token.value,
+                attributes=attributes,
+                children=[],
+                self_closing=True,
+                line=open_token.line,
+                column=open_token.column,
+            )
         self._consume(TokenType.TAG_END, "Expected '>' after opening component tag")
         children = self._parse_children_until(TokenType.COMPONENT_TAG_CLOSE, open_token.value)
         self._consume(TokenType.COMPONENT_TAG_CLOSE, f"Expected closing tag </{open_token.value}>")
@@ -365,6 +376,7 @@ class DjuleParser:
             name=open_token.value,
             attributes=attributes,
             children=children,
+            self_closing=False,
             line=open_token.line,
             column=open_token.column,
         )

--- a/src/djule/parser/printer.py
+++ b/src/djule/parser/printer.py
@@ -133,10 +133,10 @@ class DjulePrinter:
             return self._print_embedded_block(node, indent)
 
         if isinstance(node, ElementNode):
-            return self._print_tag_block(node.tag, node.attributes, node.children, indent)
+            return self._print_tag_block(node.tag, node.attributes, node.children, node.self_closing, indent)
 
         if isinstance(node, ComponentNode):
-            return self._print_tag_block(node.name, node.attributes, node.children, indent)
+            return self._print_tag_block(node.name, node.attributes, node.children, node.self_closing, indent)
 
         raise TypeError(f"Unsupported markup node: {type(node)!r}")
 
@@ -154,6 +154,7 @@ class DjulePrinter:
         name: str,
         attributes: list[AttributeNode],
         children: list[MarkupNode],
+        self_closing: bool,
         indent: int,
     ) -> list[str]:
         """Render either an HTML tag or component tag block.
@@ -163,6 +164,9 @@ class DjulePrinter:
         """
         prefix = "    " * indent
         open_tag = self._format_open_tag(name, attributes)
+
+        if self_closing:
+            return [f"{prefix}{open_tag[:-1]} />"]
 
         if not children:
             return [f"{prefix}{open_tag}</{name}>"]
@@ -207,10 +211,14 @@ class DjulePrinter:
         if isinstance(node, BlockNode):
             raise TypeError("Embedded blocks cannot be printed inline")
         if isinstance(node, ElementNode):
+            if node.self_closing:
+                return f"{self._format_open_tag(node.tag, node.attributes)[:-1]} />"
             open_tag = self._format_open_tag(node.tag, node.attributes)
             children = "".join(self._print_inline_markup(child) for child in node.children)
             return f"{open_tag}{children}</{node.tag}>"
         if isinstance(node, ComponentNode):
+            if node.self_closing:
+                return f"{self._format_open_tag(node.name, node.attributes)[:-1]} />"
             open_tag = self._format_open_tag(node.name, node.attributes)
             children = "".join(self._print_inline_markup(child) for child in node.children)
             return f"{open_tag}{children}</{node.name}>"

--- a/src/djule/parser/tokens.py
+++ b/src/djule/parser/tokens.py
@@ -43,6 +43,7 @@ class TokenType(str, Enum):
     COMPONENT_TAG_CLOSE = "COMPONENT_TAG_CLOSE"  # closing component tag name token (e.g. "Button")
     DECLARATION = "DECLARATION"  # raw markup declaration such as <!doctype html>
     TAG_END = "TAG_END"  # literal ">" that ends an opening/closing tag
+    SELF_TAG_END = "SELF_TAG_END"  # literal "/>" that ends a self-closing opening tag
     ATTR_NAME = "ATTR_NAME"  # attribute name inside a tag (e.g. class, id, custom props)
     TEXT = "TEXT"  # plain text content inside markup
     EXPR = "EXPR"  # embedded expression inside markup: { python_expression }

--- a/src/djule/parser/tree_printer.py
+++ b/src/djule/parser/tree_printer.py
@@ -198,8 +198,12 @@ class DjuleTreePrinter:
         if isinstance(node, FragmentNode):
             return "FragmentNode"
         if isinstance(node, ElementNode):
+            if node.self_closing:
+                return f"ElementNode <{node.tag} />"
             return f"ElementNode <{node.tag}>"
         if isinstance(node, ComponentNode):
+            if node.self_closing:
+                return f"ComponentNode <{node.name} />"
             return f"ComponentNode <{node.name}>"
         if isinstance(node, BlockNode):
             return "BlockNode"

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -51,6 +51,22 @@ class LexerTests(unittest.TestCase):
         declaration = next(token for token in tokens if token.type == TokenType.DECLARATION)
         self.assertEqual(declaration.value, "<!doctype html>")
 
+    def test_self_closing_tags_tokenize_with_dedicated_tag_end(self):
+        source = """def Page():
+    return (
+        <main>
+            <img src="hero.png" />
+            <Button variant="primary" />
+        </main>
+    )
+"""
+
+        tokens = DjuleLexer(source).tokenize()
+
+        self.assertEqual(sum(token.type == TokenType.SELF_TAG_END for token in tokens), 2)
+        self.assertIn("img", [token.value for token in tokens if token.type == TokenType.HTML_TAG_OPEN])
+        self.assertIn("Button", [token.value for token in tokens if token.type == TokenType.COMPONENT_TAG_OPEN])
+
     def test_children_example_has_component_nodes_and_text(self):
         tokens = self.lex("03_children.djule")
         values = [token.value for token in tokens]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -171,6 +171,31 @@ def Page():
         self.assertIsInstance(root.children[1], ElementNode)
         self.assertEqual(root.children[1].tag, "html")
 
+    def test_self_closing_html_and_component_tags_parse(self):
+        source = """
+def Page():
+    return (
+        <main>
+            <img src="hero.png" />
+            <Button variant="primary" />
+        </main>
+    )
+"""
+        module = DjuleParser.from_source(source).parse()
+
+        root = module.components[0].return_stmt.value
+        self.assertIsInstance(root, ElementNode)
+
+        image = root.children[0]
+        self.assertIsInstance(image, ElementNode)
+        self.assertTrue(image.self_closing)
+        self.assertEqual(image.children, [])
+
+        button = root.children[1]
+        self.assertIsInstance(button, ComponentNode)
+        self.assertTrue(button.self_closing)
+        self.assertEqual(button.children, [])
+
     def test_children_attribute_is_rejected_on_component_tags(self):
         source = """
 def Page():

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -78,6 +78,27 @@ class RendererTests(unittest.TestCase):
         renderer = DjuleRenderer.from_source(source)
         self.assertEqual(renderer.render(), "<!doctype html><html><body>Hello</body></html>")
 
+    def test_self_closing_html_and_component_tags_render(self):
+        source = """def Button(variant, children):
+    return (
+        <button data-variant={variant}>{children}</button>
+    )
+
+def Page():
+    return (
+        <main>
+            <img src="hero.png" />
+            <Button variant="primary" />
+        </main>
+    )
+"""
+
+        renderer = DjuleRenderer.from_source(source)
+        self.assertEqual(
+            renderer.render(),
+            '<main><img src="hero.png" /><button data-variant="primary"></button></main>',
+        )
+
     def test_from_file_reuses_cached_parsed_module_when_source_is_unchanged(self):
         first = DjuleRenderer.from_file(example_path("01_simple_page.djule"))
         second = DjuleRenderer.from_file(example_path("01_simple_page.djule"))


### PR DESCRIPTION
## Summary
Add lexer, parser, renderer, printer, and cache support for `/>` on HTML and component tags.

Closes #11