### PR TITLE
Restore VS Code support in external workspaces

### DIFF
--- a/syntax/vscode-djule/README.md
+++ b/syntax/vscode-djule/README.md
@@ -31,6 +31,7 @@ Make the v1 examples readable in VS Code before building parser-aware semantic h
 - Otherwise it asks the Python extension for the workspace-selected interpreter, then falls back to common local environment names like `.venv`, `venv`, and `env`, and only uses `python3` as a last resort.
 - You can still override the interpreter explicitly with the `djule.pythonCommand` VS Code setting.
 - The extension auto-detects the Djule project root by walking upward from the file until it finds the local `src/djule` package layout.
+- If no local Djule source tree is found, the extension falls back to the current workspace folder so completions and diagnostics still work in apps that only consume the published `djule` package.
 - If auto-detection fails, set `djule.projectRoot` to the absolute repo path.
 - You can disable live checking with the `djule.liveSyntax` setting.
 

--- a/syntax/vscode-djule/lib/completions.js
+++ b/syntax/vscode-djule/lib/completions.js
@@ -10,30 +10,34 @@ const {
 } = require("./symbols");
 
 function provideDjuleCompletions(document, position, context, configuration) {
-  const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
-  const runtimeRoot = resolveRuntimeRoot(document, context, configuration);
-  const symbols = collectDocumentSymbols(document, runtimeRoot.cwd);
-  const importItems = buildImportCompletions(linePrefix, document, position, runtimeRoot.cwd);
+  try {
+    const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
+    const runtimeRoot = resolveRuntimeRoot(document, context, configuration);
+    const symbols = collectDocumentSymbols(document, runtimeRoot.cwd);
+    const importItems = buildImportCompletions(linePrefix, document, position, runtimeRoot.cwd);
 
-  if (importItems !== null) {
-    return importItems;
-  }
+    if (importItems !== null) {
+      return importItems;
+    }
 
-  if (isComponentAttributeContext(linePrefix)) {
-    return buildAttributeCompletions(linePrefix, position, symbols);
-  }
+    if (isComponentAttributeContext(linePrefix)) {
+      return buildAttributeCompletions(linePrefix, position, symbols);
+    }
 
-  if (isTagContext(linePrefix)) {
-    return buildTagCompletions(linePrefix, position, symbols);
-  }
+    if (isTagContext(linePrefix)) {
+      return buildTagCompletions(linePrefix, position, symbols);
+    }
 
-  if (isMemberAccessContext(linePrefix)) {
-    return buildMemberAccessCompletions(linePrefix, position, symbols);
-  }
+    if (isMemberAccessContext(linePrefix)) {
+      return buildMemberAccessCompletions(linePrefix, position, symbols);
+    }
 
-  const codeItems = buildCodeCompletions(document, position, symbols);
-  if (codeItems !== null) {
-    return codeItems;
+    const codeItems = buildCodeCompletions(document, position, symbols);
+    if (codeItems !== null) {
+      return codeItems;
+    }
+  } catch (_error) {
+    // Fall back to generic Djule keywords/snippets instead of failing silently.
   }
 
   return buildKeywordAndSnippetCompletions(document, position);

--- a/syntax/vscode-djule/lib/diagnostics.js
+++ b/syntax/vscode-djule/lib/diagnostics.js
@@ -33,8 +33,25 @@ function registerDiagnostics(context) {
     }
 
     const configuration = vscode.workspace.getConfiguration("djule", document);
-    const pythonCommand = await resolvePythonCommand(document, configuration);
-    const runtimeRoot = resolveRuntimeRoot(document, context, configuration);
+    let pythonCommand;
+    let runtimeRoot;
+    try {
+      pythonCommand = await resolvePythonCommand(document, configuration);
+      runtimeRoot = resolveRuntimeRoot(document, context, configuration);
+    } catch (error) {
+      if (document.isClosed || document.version !== expectedVersion) {
+        return;
+      }
+
+      diagnostics.set(document.uri, [
+        new vscode.Diagnostic(
+          fallbackRange(document),
+          `Djule extension failed to prepare live syntax checking: ${error.message}`,
+          vscode.DiagnosticSeverity.Error
+        ),
+      ]);
+      return;
+    }
 
     const child = cp.spawn(
       pythonCommand,

--- a/syntax/vscode-djule/lib/runtime.js
+++ b/syntax/vscode-djule/lib/runtime.js
@@ -85,6 +85,7 @@ function resolveImportedModulePath(document, moduleName, runtimeRoot) {
 function resolveRuntimeRoot(document, context, configuration) {
   const configuredRoot = configuration.get("projectRoot", "").trim();
   const candidates = listRuntimeCandidateDirectories(document);
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
   if (configuredRoot) {
     candidates.unshift(configuredRoot);
   }
@@ -110,7 +111,9 @@ function resolveRuntimeRoot(document, context, configuration) {
     }
   }
 
-  const fallback = workspaceFolder ? workspaceFolder.uri.fsPath : process.cwd();
+  const fallback =
+    (workspaceFolder && workspaceFolder.uri.fsPath) ||
+    (document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : process.cwd());
   return {
     cwd: fallback,
     env: {},


### PR DESCRIPTION
## Summary
Fix the VS Code extension so completions and live diagnostics keep working in external app workspaces like Wheelify, even when the workspace is not the Djule repo itself.

Closes #20