### PR TITLE
[codex] Preserve imported component error context

### DIFF
--- a/src/djule/compiler/plan_support.py
+++ b/src/djule/compiler/plan_support.py
@@ -73,9 +73,14 @@ class DjulePlanMixin:
         bindings: dict[str, tuple[str, object]],
     ) -> tuple[list[PlanPart], bool]:
         """Compile one component with any known prop/local bindings already applied."""
-        body_bindings, fully_flattened = self._compile_component_body_bindings(component.body, bindings)
-        active_bindings = body_bindings if fully_flattened else bindings
-        return self._compile_markup_plan(component.return_stmt.value, active_bindings), not fully_flattened
+        previous_component_name = self._current_compiling_component_name
+        self._current_compiling_component_name = component.name
+        try:
+            body_bindings, fully_flattened = self._compile_component_body_bindings(component.body, bindings)
+            active_bindings = body_bindings if fully_flattened else bindings
+            return self._compile_markup_plan(component.return_stmt.value, active_bindings), not fully_flattened
+        finally:
+            self._current_compiling_component_name = previous_component_name
 
     def _compile_component_body_bindings(
         self,
@@ -174,16 +179,16 @@ class DjulePlanMixin:
         """
         binding = self._binding_for_expression(source, bindings)
         if binding is None:
-            return [ExprPart(source, line=line, column=column)]
+            return [self._expr_part(source, line=line, column=column)]
 
         binding_type, value = binding
         if binding_type == "literal":
             return [StaticPart(str(self._render_expression_value(value)))]
         if binding_type == "expr":
-            return [ExprPart(str(value), line=line, column=column)]
+            return [self._expr_part(str(value), line=line, column=column)]
         if binding_type in {"children", "plan"}:
             return list(value)
-        return [ExprPart(source, line=line, column=column)]
+        return [self._expr_part(source, line=line, column=column)]
 
     def _compile_attribute_parts(
         self,
@@ -204,13 +209,13 @@ class DjulePlanMixin:
             if binding_type == "expr":
                 return [
                     StaticPart(f' {attribute.name}="'),
-                    AttrExprPart(str(value), line=attribute.value.line, column=attribute.value.column),
+                    self._attr_expr_part(str(value), line=attribute.value.line, column=attribute.value.column),
                     StaticPart('"'),
                 ]
 
         return [
             StaticPart(f' {attribute.name}="'),
-            AttrExprPart(attribute.value.source, line=attribute.value.line, column=attribute.value.column),
+            self._attr_expr_part(attribute.value.source, line=attribute.value.line, column=attribute.value.column),
             StaticPart('"'),
         ]
 
@@ -311,6 +316,8 @@ class DjulePlanMixin:
     ) -> list[PlanPart] | None:
         """Try to inline another component's compiled plan into the current one."""
         if isinstance(component, ImportedComponentRef):
+            if component.renderer._module_import_values():
+                return None
             resolved = component.renderer._resolve_component(component.component_name)
             if isinstance(resolved, ComponentDef):
                 parts, requires_runtime_body = component.renderer._compile_component_with_bindings(resolved, bindings)
@@ -392,6 +399,26 @@ class DjulePlanMixin:
         """Record that the current compiled plan depends on the given source path."""
         if self._plan_dependency_paths is not None:
             self._plan_dependency_paths.add(path.resolve())
+
+    def _expr_part(self, source: str, *, line: int = 0, column: int = 0) -> ExprPart:
+        """Build one expression plan part tagged with its source module/component."""
+        return ExprPart(
+            source,
+            line=line,
+            column=column,
+            source_path=str(self.module_path) if self.module_path is not None else None,
+            component_name=self._current_compiling_component_name,
+        )
+
+    def _attr_expr_part(self, source: str, *, line: int = 0, column: int = 0) -> AttrExprPart:
+        """Build one attribute-expression plan part tagged with its source module/component."""
+        return AttrExprPart(
+            source,
+            line=line,
+            column=column,
+            source_path=str(self.module_path) if self.module_path is not None else None,
+            component_name=self._current_compiling_component_name,
+        )
 
     @staticmethod
     def _merge_static_parts(parts: list[PlanPart]) -> list[PlanPart]:

--- a/src/djule/compiler/render_plan.py
+++ b/src/djule/compiler/render_plan.py
@@ -19,6 +19,8 @@ class ExprPart:
     source: str
     line: int = 0
     column: int = 0
+    source_path: str | None = None
+    component_name: str | None = None
     type: str = field(init=False, default="ExprPart")
 
 
@@ -28,6 +30,8 @@ class AttrExprPart:
     source: str
     line: int = 0
     column: int = 0
+    source_path: str | None = None
+    component_name: str | None = None
     type: str = field(init=False, default="AttrExprPart")
 
 

--- a/src/djule/compiler/render_support.py
+++ b/src/djule/compiler/render_support.py
@@ -101,11 +101,13 @@ class DjuleRenderMixin:
         component_name: str | None = None,
         line: int = 0,
         column: int = 0,
+        source_path: str | None = None,
     ) -> str:
         """Format a runtime error with file/component/location details first."""
         context_parts = []
-        if self.module_path is not None:
-            context_parts.append(f"file '{self.module_path}'")
+        effective_source_path = source_path or (str(self.module_path) if self.module_path is not None else None)
+        if effective_source_path is not None:
+            context_parts.append(f"file '{effective_source_path}'")
         active_component_name = component_name or self._current_component_name
         if active_component_name:
             context_parts.append(f"component '{active_component_name}'")
@@ -256,12 +258,26 @@ class DjuleRenderMixin:
         if isinstance(part, ExprPart):
             return str(
                 self._render_expression_value(
-                    self._eval_python_expr(part.source, env, line=part.line, column=part.column)
+                    self._eval_python_expr(
+                        part.source,
+                        env,
+                        line=part.line,
+                        column=part.column,
+                        source_path=part.source_path,
+                        component_name=part.component_name,
+                    )
                 )
             )
 
         if isinstance(part, AttrExprPart):
-            value = self._eval_python_expr(part.source, env, line=part.line, column=part.column)
+            value = self._eval_python_expr(
+                part.source,
+                env,
+                line=part.line,
+                column=part.column,
+                source_path=part.source_path,
+                component_name=part.component_name,
+            )
             if value is None:
                 return ""
             return escape(str(value), quote=True)
@@ -470,6 +486,8 @@ class DjuleRenderMixin:
         *,
         line: int = 0,
         column: int = 0,
+        source_path: str | None = None,
+        component_name: str | None = None,
     ) -> object:
         """Evaluate a Python expression in the current Djule environment.
 
@@ -479,11 +497,12 @@ class DjuleRenderMixin:
         """
         scope = {"__builtins__": self.builtins, **env}
         try:
-            code = self._compiled_expr_cache.get(source)
+            filename = source_path or (str(self.module_path) if self.module_path is not None else "<djule>")
+            cache_key = (filename, source)
+            code = self._compiled_expr_cache.get(cache_key)
             if code is None:
-                filename = str(self.module_path) if self.module_path is not None else "<djule>"
                 code = compile(source, filename, "eval")
-                self._compiled_expr_cache[source] = code
+                self._compiled_expr_cache[cache_key] = code
             return eval(code, scope, scope)
         except Exception as exc:  # pragma: no cover
             raise RendererError(
@@ -491,5 +510,7 @@ class DjuleRenderMixin:
                     f"Failed to evaluate expression '{source}': {exc}",
                     line=line,
                     column=column,
+                    component_name=component_name,
+                    source_path=source_path,
                 )
             ) from exc

--- a/src/djule/compiler/renderer.py
+++ b/src/djule/compiler/renderer.py
@@ -21,9 +21,9 @@ class DjuleRenderer(DjuleCacheMixin, DjulePlanMixin, DjuleImportMixin, DjuleRend
     responsibilities remain easier to reason about.
     """
 
-    CACHE_VERSION: ClassVar[int] = 10
+    CACHE_VERSION: ClassVar[int] = 11
     _parsed_module_cache: ClassVar[dict[Path, tuple[int, int, Module]]] = {}
-    _compiled_expr_cache: ClassVar[dict[str, CodeType]] = {}
+    _compiled_expr_cache: ClassVar[dict[tuple[str, str], CodeType]] = {}
     _entry_plan_cache: ClassVar[
         dict[tuple[Path, str], tuple[int, int, ComponentPlan, tuple[tuple[str, int, int], ...]]]
     ] = {}
@@ -80,4 +80,5 @@ class DjuleRenderer(DjuleCacheMixin, DjulePlanMixin, DjuleImportMixin, DjuleRend
         self._instance_component_plans: dict[str, ComponentPlan] = {}
         self._plan_dependency_paths: set[Path] | None = None
         self._current_component_name: str | None = None
+        self._current_compiling_component_name: str | None = None
         self._ambient_props_stack: list[dict[str, object]] = []

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -206,11 +206,19 @@ def Page():
 
         payload = self.load_plan_payload("12_cache_demo.djule")
         page_plan = payload["plan"]
+        expr_path = str(example_path("12_cache_demo.djule").resolve())
         self.assertEqual(
             page_plan["parts"],
             [
                 {"type": "StaticPart", "value": '<section class="card"><h1>'},
-                {"type": "ExprPart", "source": "title", "line": 6, "column": 17},
+                {
+                    "type": "ExprPart",
+                    "source": "title",
+                    "line": 6,
+                    "column": 17,
+                    "source_path": expr_path,
+                    "component_name": "Page",
+                },
                 {
                     "type": "StaticPart",
                     "value": '</h1><p>This paragraph Different is static and should be cached to disk.</p>'
@@ -265,7 +273,17 @@ def Page():
         payload = self.load_plan_payload("13_multi_component_cache_demo.djule")
         page_plan = payload["plan"]
         self.assertEqual(len(page_plan["parts"]), 3)
-        self.assertEqual(page_plan["parts"][1], {"type": "ExprPart", "source": "user_name", "line": 17, "column": 27})
+        self.assertEqual(
+            page_plan["parts"][1],
+            {
+                "type": "ExprPart",
+                "source": "user_name",
+                "line": 17,
+                "column": 27,
+                "source_path": str(example_path("13_multi_component_cache_demo.djule").resolve()),
+                "component_name": "Page",
+            },
+        )
 
     def test_simple_helper_assignments_are_flattened_into_component_plan(self):
         self.render(
@@ -282,7 +300,17 @@ def Page():
         self.assertIn("btn btn-", button_plan["parts"][1]["source"])
         self.assertIn("variant", button_plan["parts"][1]["source"])
         self.assertEqual(button_plan["parts"][2], {"type": "StaticPart", "value": '">'})
-        self.assertEqual(button_plan["parts"][3], {"type": "ExprPart", "source": "children", "line": 13, "column": 13})
+        self.assertEqual(
+            button_plan["parts"][3],
+            {
+                "type": "ExprPart",
+                "source": "children",
+                "line": 13,
+                "column": 13,
+                "source_path": str(example_path("components/ui.djule").resolve()),
+                "component_name": "Button",
+            },
+        )
         self.assertEqual(button_plan["parts"][4], {"type": "StaticPart", "value": "</button>"})
 
     def test_page_render_only_persists_the_entry_component_plan(self):
@@ -628,6 +656,73 @@ def Page():
                 renderer.render(ambient_props={"csrf_token": "token-123"}),
                 "<main><form>token-123</form></main>",
             )
+
+    def test_imported_component_keeps_its_builtin_import_scope(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            components_dir = root / "components"
+            components_dir.mkdir()
+
+            (root / "page.djule").write_text(
+                """from components.layout import LoginDocument
+
+def Page():
+    return (
+        <LoginDocument></LoginDocument>
+    )
+"""
+            )
+            (components_dir / "layout.djule").write_text(
+                """from builtins import static
+
+def LoginDocument():
+    return (
+        <main data-icon={static("svg/wheelify.svg")}></main>
+    )
+"""
+            )
+
+            renderer = DjuleRenderer.from_file(
+                root / "page.djule",
+                search_paths=[root],
+                importables={"static": lambda path: f"/static/{path}"},
+            )
+            self.assertEqual(
+                renderer.render(),
+                '<main data-icon="/static/svg/wheelify.svg"></main>',
+            )
+
+    def test_inlined_imported_component_error_uses_imported_file_context(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            components_dir = root / "components"
+            components_dir.mkdir()
+            layout_path = components_dir / "layout.djule"
+
+            (root / "page.djule").write_text(
+                """from components.layout import LoginDocument
+
+def Page():
+    return (
+        <LoginDocument></LoginDocument>
+    )
+"""
+            )
+            layout_path.write_text(
+                """def LoginDocument():
+    return (
+        <main>{missing_name}</main>
+    )
+"""
+            )
+
+            renderer = DjuleRenderer.from_file(root / "page.djule", search_paths=[root])
+            with self.assertRaises(RendererError) as ctx:
+                renderer.render()
+
+        message = str(ctx.exception)
+        self.assertTrue(message.startswith(f"file '{layout_path.resolve()}', component 'LoginDocument', line 3, column 15:"))
+        self.assertIn("Failed to evaluate expression 'missing_name'", message)
 
     def test_virtual_builtins_module_exposes_importable_helpers(self):
         source = """from builtins import static


### PR DESCRIPTION
Closes #26

## What changed
- tag compiled expression plan parts with their source Djule file and component name
- preserve that metadata when rendering plan expressions so runtime errors point at the originating imported component
- avoid inlining imported components that carry their own imported helper values, so child builtin/import scope is preserved
- update renderer plan-cache expectations and add regressions for imported builtin scope and imported-file error attribution

## Why
Imported component expressions could be evaluated and reported as if they belonged to the parent page when the child component was inlined into the parent render plan. That made errors like `static(...) is not defined` show up against the wrong file and could lose the imported child scope.

## Impact
- runtime errors now report the actual imported Djule file and component
- child components that import helpers like `static` keep their own scope during render-plan execution
- cache metadata stays valid via a cache version bump

## Validation
- `./.venv/bin/python -m unittest tests.test_django_integration tests.test_parser tests.test_renderer tests.test_cli`
- `git diff --check`