### PR TITLE
Fix VS Code Django import-root resolution

### DIFF
--- a/src/djule/integrations/django.py
+++ b/src/djule/integrations/django.py
@@ -497,7 +497,7 @@ def discover_djule_editor_globals(
     document_path: str | Path | None = None,
     workspace_path: str | Path | None = None,
 ) -> dict[str, object]:
-    """Discover Django-backed globals and importable builtins for editor tooling."""
+    """Discover Django-backed globals, builtins, and import roots for editor tooling."""
     globals_schema: dict[str, object] = {}
     request = _editor_request_stub()
     resolved_settings = _ensure_django_settings(
@@ -541,9 +541,15 @@ def discover_djule_editor_globals(
         if isinstance(name, str) and name.isidentifier()
     }
 
+    search_paths = [
+        str(path)
+        for path in get_djule_search_paths(settings_obj=resolved_settings or settings_obj)
+    ]
+
     return {
         "builtins": tag_schema,
         "globals": globals_schema,
+        "searchPaths": search_paths,
     }
 
 

--- a/src/djule/parser/__main__.py
+++ b/src/djule/parser/__main__.py
@@ -149,7 +149,7 @@ def _discover_editor_globals_payload(
             settings_module=settings_module,
         )
     except Exception:
-        discovery_payload = {"builtins": {}, "globals": {}}
+        discovery_payload = {"builtins": {}, "globals": {}, "searchPaths": []}
     return {"ok": True, **discovery_payload}
 
 

--- a/syntax/vscode-djule/lib/completions.js
+++ b/syntax/vscode-djule/lib/completions.js
@@ -10,6 +10,8 @@ const {
 } = require("./globals");
 const {
   listDjuleModules,
+  normalizeSearchPaths,
+  resolveImportRoots,
   resolveImportedModulePath,
   resolvePythonCommand,
   resolveRuntimeRoot,
@@ -25,9 +27,14 @@ async function provideDjuleCompletions(document, position, context, configuratio
   try {
     const linePrefix = document.lineAt(position.line).text.slice(0, position.character);
     const runtimeRoot = resolveRuntimeRoot(document, context, configuration);
-    const symbols = collectDocumentSymbols(document, runtimeRoot.cwd);
-    const { builtinSymbols, globalSymbols } = await resolveGlobalSymbols(document, context, configuration, runtimeRoot);
-    const importItems = buildImportCompletions(linePrefix, document, position, runtimeRoot.cwd, builtinSymbols);
+    const { builtinSymbols, globalSymbols, importRoots } = await resolveGlobalSymbols(
+      document,
+      context,
+      configuration,
+      runtimeRoot
+    );
+    const symbols = collectDocumentSymbols(document, importRoots);
+    const importItems = buildImportCompletions(linePrefix, document, position, importRoots, builtinSymbols);
 
     if (importItems !== null) {
       return importItems;
@@ -58,17 +65,20 @@ async function provideDjuleCompletions(document, position, context, configuratio
 
 async function resolveGlobalSymbols(document, context, configuration, runtimeRoot) {
   const configuredGlobals = parseConfiguredGlobals(configuration);
+  const fallbackRoots = resolveImportRoots(runtimeRoot);
 
   try {
     const discovered = await discoverDjangoSymbols(document, context, configuration, runtimeRoot);
     return {
       builtinSymbols: discovered.builtinSymbols,
       globalSymbols: mergeGlobalSymbols(configuredGlobals, discovered.globalSymbols),
+      importRoots: resolveImportRoots([...discovered.searchPaths, ...fallbackRoots]),
     };
   } catch (_error) {
     return {
       builtinSymbols: new Map(),
       globalSymbols: configuredGlobals,
+      importRoots: fallbackRoots,
     };
   }
 }
@@ -78,6 +88,7 @@ async function discoverDjangoSymbols(document, context, configuration, runtimeRo
     return {
       builtinSymbols: new Map(),
       globalSymbols: new Map(),
+      searchPaths: [],
     };
   }
 
@@ -94,12 +105,14 @@ async function discoverDjangoSymbols(document, context, configuration, runtimeRo
     return {
       builtinSymbols: new Map(),
       globalSymbols: new Map(),
+      searchPaths: [],
     };
   }
 
   return {
     builtinSymbols: parseGlobalSchema(payload.builtins),
     globalSymbols: parseGlobalSchema(payload.globals),
+    searchPaths: normalizeSearchPaths(payload.searchPaths),
   };
 }
 
@@ -119,7 +132,7 @@ function isMemberAccessContext(linePrefix) {
   return /\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*\.[A-Za-z_0-9]*$/.test(linePrefix);
 }
 
-function buildImportCompletions(linePrefix, document, position, runtimeRoot, builtinSymbols) {
+function buildImportCompletions(linePrefix, document, position, importRoots, builtinSymbols) {
   if (/^\s*from\s*$/.test(linePrefix) || /^\s*import\s*$/.test(linePrefix)) {
     return [];
   }
@@ -140,7 +153,7 @@ function buildImportCompletions(linePrefix, document, position, runtimeRoot, bui
             return item;
           });
       }
-      const modulePath = resolveImportedModulePath(document, moduleName, runtimeRoot);
+      const modulePath = resolveImportedModulePath(document, moduleName, importRoots);
       if (!modulePath) {
         return [];
       }
@@ -158,12 +171,12 @@ function buildImportCompletions(linePrefix, document, position, runtimeRoot, bui
 
     const fromModuleMatch = linePrefix.match(/^\s*from\s+([.\w]*)$/);
     if (fromModuleMatch) {
-      return buildModulePathCompletions(document, position, runtimeRoot, fromModuleMatch[1] || "");
+      return buildModulePathCompletions(document, position, importRoots, fromModuleMatch[1] || "");
     }
 
     const bareImportMatch = linePrefix.match(/^\s*import\s+([.\w]*)$/);
     if (bareImportMatch) {
-      return buildModulePathCompletions(document, position, runtimeRoot, bareImportMatch[1] || "");
+      return buildModulePathCompletions(document, position, importRoots, bareImportMatch[1] || "");
     }
 
     return [];
@@ -172,8 +185,8 @@ function buildImportCompletions(linePrefix, document, position, runtimeRoot, bui
   return null;
 }
 
-function buildModulePathCompletions(document, position, runtimeRoot, modulePrefix) {
-  const moduleNames = listDjuleModules(document, runtimeRoot, modulePrefix);
+function buildModulePathCompletions(document, position, importRoots, modulePrefix) {
+  const moduleNames = listDjuleModules(document, importRoots, modulePrefix);
   if ("builtins".startsWith(modulePrefix || "")) {
     moduleNames.unshift("builtins");
   }

--- a/syntax/vscode-djule/lib/diagnostics.js
+++ b/syntax/vscode-djule/lib/diagnostics.js
@@ -6,9 +6,8 @@ const {
   configuredGlobalNames,
   mergeGlobalSymbols,
   parseConfiguredGlobals,
-  parseGlobalSchema,
 } = require("./globals");
-const { resolvePythonCommand, resolveRuntimeRoot } = require("./runtime");
+const { normalizeSearchPaths, resolveImportRoots, resolvePythonCommand, resolveRuntimeRoot } = require("./runtime");
 
 function registerDiagnostics(context) {
   const diagnostics = vscode.languages.createDiagnosticCollection(DIAGNOSTIC_SOURCE);
@@ -46,8 +45,8 @@ function registerDiagnostics(context) {
       const pythonCommand = await resolvePythonCommand(document, configuration);
       const runtimeRoot = resolveRuntimeRoot(document, context, configuration);
       const server = serverPool.getServer(pythonCommand, runtimeRoot);
-      const globalNames = await resolveGlobalNames(document, server, configuration);
-      payload = await server.checkDocument(document, globalNames);
+      const editorContext = await resolveEditorContext(document, server, configuration, runtimeRoot);
+      payload = await server.checkDocument(document, editorContext.globalNames, editorContext.searchPaths);
     } catch (error) {
       if (document.isClosed || document.version !== expectedVersion) {
         return;
@@ -166,20 +165,33 @@ function fallbackRange(document) {
   return diagnosticRange(document, 1, 1);
 }
 
-async function resolveGlobalNames(document, server, configuration) {
+async function resolveEditorContext(document, server, configuration, runtimeRoot) {
   const configuredGlobals = parseConfiguredGlobals(configuration);
+  const fallbackContext = {
+    globalNames: configuredGlobalNames(configuredGlobals),
+    searchPaths: resolveImportRoots(runtimeRoot),
+  };
 
   try {
-    const discoveredGlobals = await discoverDjangoContextGlobals(document, server, configuration);
-    return configuredGlobalNames(mergeGlobalSymbols(configuredGlobals, discoveredGlobals));
+    const discovered = await discoverDjangoContext(document, server, configuration, runtimeRoot);
+    return {
+      globalNames: configuredGlobalNames(mergeGlobalSymbols(configuredGlobals, discovered.globalSymbols)),
+      searchPaths: resolveImportRoots([
+        ...discovered.searchPaths,
+        ...resolveImportRoots(runtimeRoot),
+      ]),
+    };
   } catch (_error) {
-    return configuredGlobalNames(configuredGlobals);
+    return fallbackContext;
   }
 }
 
-async function discoverDjangoContextGlobals(document, server, configuration) {
+async function discoverDjangoContext(document, server, configuration, runtimeRoot) {
   if (document.uri.scheme !== "file") {
-    return new Map();
+    return {
+      globalSymbols: new Map(),
+      searchPaths: resolveImportRoots(runtimeRoot),
+    };
   }
 
   const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
@@ -188,11 +200,17 @@ async function discoverDjangoContextGlobals(document, server, configuration) {
     workspacePath: workspaceFolder ? workspaceFolder.uri.fsPath : "",
   });
 
-  if (!payload || !payload.ok || typeof payload.globals !== "object" || payload.globals === null) {
-    return new Map();
+  if (!payload || !payload.ok) {
+    return {
+      globalSymbols: new Map(),
+      searchPaths: resolveImportRoots(runtimeRoot),
+    };
   }
 
-  return parseGlobalSchema(payload.globals);
+  return {
+    globalSymbols: parseGlobalSchema(payload.globals),
+    searchPaths: normalizeSearchPaths(payload.searchPaths),
+  };
 }
 
 function normalizeConfiguredString(value) {

--- a/syntax/vscode-djule/lib/diagnostics_server.js
+++ b/syntax/vscode-djule/lib/diagnostics_server.js
@@ -59,11 +59,12 @@ class DjuleDiagnosticsServer {
     this.stderrBuffer = "";
   }
 
-  async checkDocument(document, globalNames = []) {
+  async checkDocument(document, globalNames = [], searchPaths = []) {
     const request = {
       command: "check",
       documentPath: document.uri.scheme === "file" ? document.uri.fsPath : undefined,
       globals: globalNames,
+      searchPaths,
       source: document.getText(),
     };
     return this.request(request);

--- a/syntax/vscode-djule/lib/runtime.js
+++ b/syntax/vscode-djule/lib/runtime.js
@@ -31,7 +31,7 @@ async function resolvePythonCommand(document, configuration) {
   return "python3";
 }
 
-function listDjuleModules(document, runtimeRoot, modulePrefix) {
+function listDjuleModules(document, importRoots, modulePrefix) {
   if (!modulePrefix) {
     return [];
   }
@@ -40,10 +40,10 @@ function listDjuleModules(document, runtimeRoot, modulePrefix) {
     return listRelativeDjuleModules(document, modulePrefix);
   }
 
-  return listAbsoluteDjuleModules(runtimeRoot, modulePrefix);
+  return listAbsoluteDjuleModules(importRoots, modulePrefix);
 }
 
-function resolveImportedModulePath(document, moduleName, runtimeRoot) {
+function resolveImportedModulePath(document, moduleName, importRoots) {
   if (moduleName.startsWith(".")) {
     if (document.uri.scheme !== "file") {
       return null;
@@ -71,13 +71,15 @@ function resolveImportedModulePath(document, moduleName, runtimeRoot) {
   }
 
   const moduleParts = moduleName.split(".");
-  const fileCandidate = path.join(runtimeRoot, ...moduleParts) + ".djule";
-  const packageCandidate = path.join(runtimeRoot, ...moduleParts, "__init__.djule");
-  if (fs.existsSync(fileCandidate)) {
-    return fileCandidate;
-  }
-  if (fs.existsSync(packageCandidate)) {
-    return packageCandidate;
+  for (const importRoot of resolveImportRoots(importRoots)) {
+    const fileCandidate = path.join(importRoot, ...moduleParts) + ".djule";
+    const packageCandidate = path.join(importRoot, ...moduleParts, "__init__.djule");
+    if (fs.existsSync(fileCandidate)) {
+      return fileCandidate;
+    }
+    if (fs.existsSync(packageCandidate)) {
+      return packageCandidate;
+    }
   }
   return null;
 }
@@ -143,9 +145,16 @@ function listRuntimeCandidateDirectories(document) {
   return dedupePaths(candidates);
 }
 
-function listAbsoluteDjuleModules(runtimeRoot, modulePrefix) {
-  const modules = collectDjuleModulesUnderRoot(runtimeRoot);
-  return nextModuleSegments(modules, modulePrefix);
+function listAbsoluteDjuleModules(importRoots, modulePrefix) {
+  const modules = new Set();
+
+  for (const importRoot of resolveImportRoots(importRoots)) {
+    for (const moduleName of collectDjuleModulesUnderRoot(importRoot)) {
+      modules.add(moduleName);
+    }
+  }
+
+  return nextModuleSegments(Array.from(modules), modulePrefix);
 }
 
 function listRelativeDjuleModules(document, modulePrefix) {
@@ -167,6 +176,33 @@ function listRelativeDjuleModules(document, modulePrefix) {
 
   const modules = collectDjuleModulesUnderRoot(baseDir);
   return nextModuleSegments(modules, remainder);
+}
+
+function resolveImportRoots(importRoots) {
+  if (Array.isArray(importRoots)) {
+    return dedupePaths(importRoots);
+  }
+
+  if (typeof importRoots === "string") {
+    return dedupePaths([importRoots]);
+  }
+
+  if (importRoots && typeof importRoots === "object") {
+    return dedupePaths([
+      ...normalizeSearchPaths(importRoots.searchPaths),
+      importRoots.cwd,
+    ]);
+  }
+
+  return [];
+}
+
+function normalizeSearchPaths(searchPaths) {
+  if (!Array.isArray(searchPaths)) {
+    return [];
+  }
+
+  return searchPaths.filter((searchPath) => typeof searchPath === "string" && searchPath.trim());
 }
 
 function collectDjuleModulesUnderRoot(rootDir) {
@@ -380,6 +416,8 @@ function safeResolve(candidate) {
 
 module.exports = {
   listDjuleModules,
+  normalizeSearchPaths,
+  resolveImportRoots,
   resolvePythonCommand,
   resolveImportedModulePath,
   resolveRuntimeRoot,

--- a/syntax/vscode-djule/lib/symbols.js
+++ b/syntax/vscode-djule/lib/symbols.js
@@ -11,10 +11,10 @@ const { resolveImportedModulePath } = require("./runtime");
 
 const moduleSignatureCache = new Map();
 
-function collectDocumentSymbols(document, runtimeRoot) {
+function collectDocumentSymbols(document, importRoots) {
   const source = document.getText();
   const components = extractComponentSignatures(source);
-  const importedComponents = extractImportedComponents(document, source, runtimeRoot);
+  const importedComponents = extractImportedComponents(document, source, importRoots);
   const importedNames = extractImportedNames(source);
 
   for (const [name, params] of importedComponents.directComponents) {
@@ -134,14 +134,14 @@ function componentContextAtPosition(document, position, source) {
   return null;
 }
 
-function extractImportedComponents(document, source, runtimeRoot) {
+function extractImportedComponents(document, source, importRoots) {
   const directComponents = new Map();
   const namespacedModules = new Map();
 
   for (const match of source.matchAll(IMPORT_FROM_RE)) {
     const moduleName = match[1];
     const importedNames = match[2].split(",").map((name) => name.trim()).filter(Boolean);
-    const modulePath = resolveImportedModulePath(document, moduleName, runtimeRoot);
+    const modulePath = resolveImportedModulePath(document, moduleName, importRoots);
     if (!modulePath) {
       continue;
     }
@@ -156,7 +156,7 @@ function extractImportedComponents(document, source, runtimeRoot) {
   for (const match of source.matchAll(IMPORT_MODULE_RE)) {
     const moduleName = match[1];
     const alias = match[2] || moduleName;
-    const modulePath = resolveImportedModulePath(document, moduleName, runtimeRoot);
+    const modulePath = resolveImportedModulePath(document, moduleName, importRoots);
     if (!modulePath) {
       continue;
     }

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -494,23 +494,26 @@ def Page():
 
     @unittest.skipUnless(importlib.util.find_spec("django") is not None, "Django is not installed")
     def test_discover_djule_editor_globals_reads_context_processors_and_global_tags(self):
-        settings_obj = SimpleNamespace(
-            TEMPLATES=[
-                {
-                    "BACKEND": DJULE_TEMPLATE_BACKEND,
-                    "OPTIONS": {
-                        "builtins": ["tests.fixture_django_tags"],
-                        "context_processors": [
-                            "django.template.context_processors.request",
-                            "tests.test_django_integration.debug_value_processor",
-                            "tests.test_django_integration.vite_host_processor",
-                        ],
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            settings_obj = SimpleNamespace(
+                TEMPLATES=[
+                    {
+                        "BACKEND": DJULE_TEMPLATE_BACKEND,
+                        "DIRS": [tmp_dir],
+                        "APP_DIRS": False,
+                        "OPTIONS": {
+                            "builtins": ["tests.fixture_django_tags"],
+                            "context_processors": [
+                                "django.template.context_processors.request",
+                                "tests.test_django_integration.debug_value_processor",
+                                "tests.test_django_integration.vite_host_processor",
+                            ],
+                        },
                     },
-                }
-            ]
-        )
+                ]
+            )
 
-        payload = discover_djule_editor_globals(settings_obj=settings_obj)
+            payload = discover_djule_editor_globals(settings_obj=settings_obj)
         globals_schema = payload["globals"]
         builtin_schema = payload["builtins"]
 
@@ -518,6 +521,7 @@ def Page():
         self.assertIn("request", globals_schema)
         self.assertIn("vite_asset", builtin_schema)
         self.assertIn("context_echo", builtin_schema)
+        self.assertEqual(payload["searchPaths"], [str(Path(tmp_dir).resolve())])
         self.assertEqual(globals_schema["request"]["members"]["user"]["members"]["username"]["detail"], "str")
         self.assertIn("vite_asset(", builtin_schema["vite_asset"]["detail"])
         self.assertIn("context_echo(", builtin_schema["context_echo"]["detail"])


### PR DESCRIPTION
## Summary
- surface Django Djule backend search paths in editor discovery payloads
- use discovered search paths for VS Code diagnostics, import resolution, and autocomplete
- add coverage for editor search path discovery from Djule backend `DIRS`

Fixes #28